### PR TITLE
Add improvements

### DIFF
--- a/lib/ex_gram/dsl.ex
+++ b/lib/ex_gram/dsl.ex
@@ -1,7 +1,15 @@
 defmodule ExGram.Dsl do
   alias ExGram.Cnt
   alias ExGram.Responses
-  alias ExGram.Responses.{Answer, AnswerCallback, EditInline, EditMarkup, DeleteMessage}
+
+  alias ExGram.Responses.{
+    Answer,
+    AnswerCallback,
+    AnswerInlineQuery,
+    EditInline,
+    EditMarkup,
+    DeleteMessage
+  }
 
   def answer(cnt, text, ops \\ [])
 
@@ -17,6 +25,10 @@ defmodule ExGram.Dsl do
 
   def answer_callback(cnt, msg, ops \\ []) do
     AnswerCallback |> Responses.new(%{ops: ops}) |> Responses.set_msg(msg) |> add_answer(cnt)
+  end
+
+  def answer_inline_query(cnt, articles, ops \\ []) do
+    AnswerInlineQuery |> Responses.new(%{articles: articles, ops: ops}) |> add_answer(cnt)
   end
 
   # /3
@@ -104,6 +116,17 @@ defmodule ExGram.Dsl do
   def extract_callback_id(%{id: cid, data: _data}), do: cid
   def extract_callback_id(cid) when is_binary(cid), do: cid
   def extract_callback_id(_), do: :error
+
+  def extract_response_id(%{message_id: id}) when not is_nil(id), do: id
+  def extract_response_id(%{id: id}) when not is_nil(id), do: id
+  def extract_response_id(%{message: m}) when not is_nil(m), do: extract_response_id(m)
+  def extract_response_id(%{callback_query: m}) when not is_nil(m), do: extract_response_id(m)
+  def extract_response_id(%{inline_query: m}) when not is_nil(m), do: extract_response_id(m)
+  def extract_response_id(%{edited_message: m}) when not is_nil(m), do: extract_response_id(m)
+  def extract_response_id(%{channel_message: m}) when not is_nil(m), do: extract_response_id(m)
+
+  def extract_response_id(%{edited_channel_post: m}) when not is_nil(m),
+    do: extract_response_id(m)
 
   def extract_message_id(%{message_id: id}), do: id
   def extract_message_id(%{message: m}) when not is_nil(m), do: extract_message_id(m)

--- a/lib/ex_gram/file.ex
+++ b/lib/ex_gram/file.ex
@@ -1,0 +1,30 @@
+defmodule ExGram.File do
+  @moduledoc """
+  Helpers when dealing with telegram files
+  """
+
+  @base_url "https://api.telegram.org/file"
+
+  @doc """
+  Generate the full file URL ready to be downloaded, usage:
+
+  First, you need to extract the File with ExGram.get_file(file_id)
+
+  Then:
+
+  ExGram.File.file_url(file)
+
+  You can pass the usual `:bot` and `:token` params:
+
+  ExGram.File.file_url(file, bot: :my_bot)
+  ExGram.File.file_url(file, token: "MyBotToken")
+  """
+  @spec file_url(ExGram.Model.File.t(), keyword) :: String.t()
+  def file_url(%ExGram.Model.File{file_path: path}, ops \\ []) do
+    token = ExGram.Token.fetch(ops)
+    create_url(token, path)
+  end
+
+  defp create_url(token, path) when is_binary(token) and is_binary(path),
+    do: @base_url <> "/bot" <> token <> "/" <> path
+end

--- a/lib/ex_gram/macros.ex
+++ b/lib/ex_gram/macros.ex
@@ -342,18 +342,7 @@ defmodule ExGram.Macros do
             Enum.map(unquote(types_mand), &check_all_types_ignore_opt/1)
             |> Enum.all?()
 
-        token =
-          case {Keyword.get(ops, :token), Keyword.get(ops, :bot)} do
-            {nil, nil} ->
-              ExGram.Config.get(:ex_gram, :token)
-
-            {token, nil} ->
-              token
-
-            {nil, bot} ->
-              [{_, token}] = Registry.lookup(Registry.ExGram, bot)
-              token
-          end
+        token = ExGram.Token.fetch(ops)
 
         debug = Keyword.get(ops, :debug, false)
 

--- a/lib/ex_gram/responses/answer_inline_query.ex
+++ b/lib/ex_gram/responses/answer_inline_query.ex
@@ -1,0 +1,18 @@
+defmodule ExGram.Responses.AnswerInlineQuery do
+  defstruct [:id, :articles, :ops]
+end
+
+defimpl ExGram.Responses, for: ExGram.Responses.AnswerInlineQuery do
+  def new(response, params), do: struct(response, params)
+
+  def execute(cb) do
+    ExGram.answer_inline_query(cb.id, cb.articles, cb.ops)
+  end
+
+  def set_msg(%{id: nil} = response, msg) do
+    id = ExGram.Dsl.extract_response_id(msg)
+    %{response | id: id}
+  end
+
+  def set_msg(response, _msg), do: response
+end

--- a/lib/ex_gram/token.ex
+++ b/lib/ex_gram/token.ex
@@ -1,0 +1,41 @@
+defmodule ExGram.Token do
+  @moduledoc """
+  Helpers when dealing with bot's tokens
+  """
+
+  @registry Registry.ExGram
+
+  @doc """
+  Main logic to extract the token of the bot.
+
+  The options can have the following keys:
+  - token: Explicit token to be used, this ignore everything else and will use this one
+  - bot: Bot name to be used, the token will be retrieved from the registry
+  - registry: Optional. Registry to extract the bot's token. By default will use ExGram.Registry.
+
+  Usage:
+
+  ExGram.Token.fetch() # Will take it from the config (config :ex_gram, token: "token")
+
+  ExGram.Token.fetch(token: "MyToken") # Will use the token
+
+  ExGram.Token.fetch(bot: :my_bot) # Will look in ExGram.Registry for :my_bot token
+
+  ExGram.Token.fetch(bot: :my_bot, registry: OtherRegistry) # Will look in OtherRegistry for :My_bot token
+  """
+  @spec fetch(keyword) :: String.t()
+  def fetch(ops \\ []) when is_list(ops) do
+    case {Keyword.get(ops, :token), Keyword.get(ops, :bot)} do
+      {nil, nil} ->
+        ExGram.Config.get(:ex_gram, :token)
+
+      {token, nil} ->
+        token
+
+      {nil, bot} ->
+        registry = Keyword.get(ops, :registry, @registry)
+        [{_, token} | _] = Registry.lookup(registry, bot)
+        token
+    end
+  end
+end


### PR DESCRIPTION
- Change the way the callback is handled so it's a {m, f, a} instead of a lambda, so you can reload the code and will work!

- Add :inline_query handler, now will call the handler with
  {:inline_query, inline}

- Add answer_inline_query to Dsl for easy answers

- Add extract_response_id which extract the *right* id (message,
  callback_query, inline_query, edited_message, channel_message, ...)

- Add ExGram.File helpers to create the file url to download

- Add ExGram.Token helpers to extract the bot token