### PR TITLE
Handle nil on updates worker

### DIFF
--- a/lib/ex_gram/bot.ex
+++ b/lib/ex_gram/bot.ex
@@ -65,6 +65,9 @@ defmodule ExGram.Bot do
             :test ->
               ExGram.Updates.Test
 
+            nil ->
+              raise "No updates method received, try with :polling or your custom module"
+
             other ->
               other
           end


### PR DESCRIPTION
Let's gime some better error if no updates worker are provided.

This usually happen when you add your bot to the supervisor's children like this `{MyBot, [:polling, token]}` instead of `{MyBot, [method: :polling, token: token]}`

And the error is cryptic, something like: `nil.start_link(...) is undefined`