### PR TITLE
Updates json_encoder -> json_engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ By default ExGram will use `Jason` engine, but you can change it to your prefere
 You can change the engine in the configuration:
 
 ``` elixir
-config :ex_gram, json_encoder: Poison
+config :ex_gram, json_engine: Poison
 ```
 
 ### Token


### PR DESCRIPTION
While trying to use Poison as json engine, I realized the config key was outdated.