### PR TITLE
Middleware fixes

### DIFF
--- a/lib/ex_gram/middleware/builder.ex
+++ b/lib/ex_gram/middleware/builder.ex
@@ -28,15 +28,21 @@ defmodule ExGram.Middleware.Builder do
 
   defmacro regex(regex, name, _opts \\ []) do
     quote do
-      @regexes [regex: Regex.compile!(unquote(regex)), name: unquote(name)]
+      @regexes [
+        regex: ExGram.Middleware.Builder.compile_regex(unquote(regex)),
+        name: unquote(name)
+      ]
     end
   end
 
+  def compile_regex(%{__struct__: Regex} = regex), do: regex
+  def compile_regex(binary) when is_binary(binary), do: Regex.compile!(binary)
+
   @doc false
   defmacro __before_compile__(env) do
-    middlewares = Module.get_attribute(env.module, :middlewares) |> Enum.reverse()
-    commands = Module.get_attribute(env.module, :commands) |> Enum.reverse()
-    regexes = Module.get_attribute(env.module, :regexes) |> Enum.reverse()
+    middlewares = Module.get_attribute(env.module, :middlewares) |> Enum.reverse() |> Macro.escape()
+    commands = Module.get_attribute(env.module, :commands) |> Enum.reverse() |> Macro.escape()
+    regexes = Module.get_attribute(env.module, :regexes) |> Enum.reverse() |> Macro.escape()
 
     quote do
       defp middlewares(), do: unquote(middlewares)

--- a/lib/ex_gram/middleware/builder.ex
+++ b/lib/ex_gram/middleware/builder.ex
@@ -40,7 +40,9 @@ defmodule ExGram.Middleware.Builder do
 
   @doc false
   defmacro __before_compile__(env) do
-    middlewares = Module.get_attribute(env.module, :middlewares) |> Enum.reverse() |> Macro.escape()
+    middlewares =
+      Module.get_attribute(env.module, :middlewares) |> Enum.reverse() |> Macro.escape()
+
     commands = Module.get_attribute(env.module, :commands) |> Enum.reverse() |> Macro.escape()
     regexes = Module.get_attribute(env.module, :regexes) |> Enum.reverse() |> Macro.escape()
 


### PR DESCRIPTION
Added macro unescape, from issue #37 with support for regex sigil syntax