### PR TITLE
Add log adapter behavior and json adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,31 @@ You can change the engine in the configuration:
 config :ex_gram, json_engine: Poison
 ```
 
+### Log Adapter
+
+You can use an alternative logger to `Logger` to format the logs as you want, `ExGram` offers the default logging using `Logger` and teh `JsonLogger` a one line JSON format.
+
+You can change the adapter in the configuration:
+
+```elixir
+config :ex_gram, log_adapter: Logger
+```
+
+If you want to use this logger in your but just import the `ExGram.LogAdapter` and you can start calling `Logger`, here is an example:
+
+Using this config:
+
+```elixir
+config :ex_gram, log_adapter: ExGram.LogAdapter.JsonLogger
+```
+
+```elixir
+use ExGram.LogAdapter
+
+Logger.debug("debug test")
+> {"log_level":"debug","message":"debug test","time":"2021-02-13 22:21:49.503110Z"}
+```
+
 ## Configuration
 
 There are some optional configuration that you can add to your `config.exs`:
@@ -218,7 +243,7 @@ ExGram.send_document(chat_id, {:file, "path/to/file"})                         #
 ExGram.send_document(chat_id, {:file_content, "FILE CONTENT", "filename.txt"}) # By content
 ```
 
-This three ways of sending files works when the API has a file field, for example `send_photo`, `send_audio`, `send_video`, ... 
+This three ways of sending files works when the API has a file field, for example `send_photo`, `send_audio`, `send_video`, ...
 
 ## Library Usage
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,7 +6,11 @@ config :maxwell, default_adapter: Maxwell.Adapter.Hackney
 
 config :tesla, adapter: Tesla.Adapter.Gun
 
-config :ex_gram, token: "TOKEN", adapter: ExGram.Adapter.Tesla, json_engine: Jason
+config :ex_gram,
+  token: "TOKEN",
+  adapter: ExGram.Adapter.Tesla,
+  json_engine: Jason,
+  log_adapter: Logger
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/ex_gram/adapter/tesla.ex
+++ b/lib/ex_gram/adapter/tesla.ex
@@ -10,7 +10,7 @@ if Code.ensure_loaded?(Tesla) do
 
     @base_url "https://api.telegram.org"
 
-    require Logger
+    use ExGram.LogAdapter
 
     plug(Tesla.Middleware.BaseUrl, ExGram.Config.get(:ex_gram, :base_url, @base_url))
     plug(Tesla.Middleware.Headers, [{"Content-Type", "application/json"}])

--- a/lib/ex_gram/log_adapter.ex
+++ b/lib/ex_gram/log_adapter.ex
@@ -1,0 +1,17 @@
+defmodule ExGram.LogAdapter do
+  @moduledoc """
+  Behaviour for loggers
+  """
+
+  @callback debug(String.t()) :: :ok
+  @callback warn(String.t()) :: :ok
+  @callback error(String.t()) :: :ok
+
+  defmacro __using__(_options) do
+    quote do
+      require Logger
+
+      alias unquote(ExGram.Config.get(:ex_gram, :log_adapter, Logger)), as: Logger
+    end
+  end
+end

--- a/lib/ex_gram/log_adapter/json_logger.ex
+++ b/lib/ex_gram/log_adapter/json_logger.ex
@@ -1,4 +1,14 @@
 defmodule ExGram.LogAdapter.JsonLogger do
+  @moduledoc """
+  Logs in a one line JSON, with the following format:
+
+    {"log_level":"<log_level>","message":"<message>","time":"<time_now>"}
+
+    - log_level -> debug, warn or error
+    - message -> string provided
+    - time -> date now with the following format: 2021-02-13 22:21:49.503110Z
+  """
+
   @behaviour ExGram.LogAdapter
 
   for log_level <- [:debug, :warn, :error] do

--- a/lib/ex_gram/log_adapter/json_logger.ex
+++ b/lib/ex_gram/log_adapter/json_logger.ex
@@ -12,6 +12,7 @@ defmodule ExGram.LogAdapter.JsonLogger do
   @behaviour ExGram.LogAdapter
 
   for log_level <- [:debug, :warn, :error] do
+    @impl ExGram.LogAdapter
     def unquote(log_level)(message),
       do:
         %{
@@ -19,7 +20,7 @@ defmodule ExGram.LogAdapter.JsonLogger do
           log_level: unquote(log_level),
           message: message
         }
-        |> Jason.encode!()
+        |> ExGram.Encoder.encode!()
         |> IO.puts()
   end
 end

--- a/lib/ex_gram/log_adapter/json_logger.ex
+++ b/lib/ex_gram/log_adapter/json_logger.ex
@@ -1,0 +1,15 @@
+defmodule ExGram.LogAdapter.JsonLogger do
+  @behaviour ExGram.LogAdapter
+
+  for log_level <- [:debug, :warn, :error] do
+    def unquote(log_level)(message),
+      do:
+        %{
+          time: DateTime.now!("Etc/UTC") |> DateTime.to_string(),
+          log_level: unquote(log_level),
+          message: message
+        }
+        |> Jason.encode!()
+        |> IO.puts()
+  end
+end

--- a/lib/ex_gram/macros/executer.ex
+++ b/lib/ex_gram/macros/executer.ex
@@ -3,7 +3,7 @@ defmodule ExGram.Macros.Executer do
   Executer for the method macro, it takes care of checking the parameters, fetching the token, building the path and body, and calling the adapter.
   """
 
-  require Logger
+  use ExGram.LogAdapter
 
   # credo:disable-for-next-line
   def execute_method(

--- a/lib/ex_gram/token.ex
+++ b/lib/ex_gram/token.ex
@@ -3,7 +3,7 @@ defmodule ExGram.Token do
   Helpers when dealing with bot's tokens
   """
 
-  require Logger
+  use ExGram.LogAdapter
 
   @registry Registry.ExGram
 

--- a/lib/ex_gram/updates/noup.ex
+++ b/lib/ex_gram/updates/noup.ex
@@ -4,7 +4,7 @@ defmodule ExGram.Updates.Noup do
   """
 
   use GenServer
-  require Logger
+  use ExGram.LogAdapter
 
   def start_link({:bot, pid, :token, token}) do
     Logger.debug("Start NO Updates worker")

--- a/lib/ex_gram/updates/polling.ex
+++ b/lib/ex_gram/updates/polling.ex
@@ -4,7 +4,7 @@ defmodule ExGram.Updates.Polling do
   """
 
   use GenServer
-  require Logger
+  use ExGram.LogAdapter
 
   @polling_timeout 100
 

--- a/lib/examples/simple.ex
+++ b/lib/examples/simple.ex
@@ -4,12 +4,11 @@ defmodule Examples.Simple do
   @bot :simple_bot
 
   use ExGram.Bot, name: @bot, setup_commands: true
+  use ExGram.LogAdapter
 
   command("echo", description: "Echo the message back to the user")
 
   middleware(ExGram.Middleware.IgnoreUsername)
-
-  require Logger
 
   def handle({:command, :echo, %{text: t}}, cnt) do
     cnt |> answer(t)


### PR DESCRIPTION
# Why

In case someone wants to log events as JSON or simply wants to specify their own way of logging.

# Usage

The idea is to `use` the `ExGram.LogAdapter` module, the module will take the adapter defined in the config or `Logger` by default and require the `Logger` so we don't have to.

# Example

Using this config:

```elixir
config :ex_gram,
  token: "TOKEN",
  adapter: ExGram.Adapter.Tesla,
  json_engine: Jason,
  log_adapter: ExGram.LogAdapter.JsonLogger
```

![image](https://user-images.githubusercontent.com/9699815/107863359-2317c280-6e54-11eb-972a-161edeb9ca75.png)
