### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ config :maxwell, default_adapter: Maxwell.Adapter.Hackney
 
 ### JSON Engine
 
-By default ExGram will use `Jason` engine, but you can change it to your prefered JSON engine, the module just has to expose `encode/2`, `encode!/2`, `decode/2`, `decode!/2`.
+By default ExGram will use `Jason` engine, but you can change it to your preferred JSON engine, the module just has to expose `encode/2`, `encode!/2`, `decode/2`, `decode!/2`.
 
 You can change the engine in the configuration:
 

--- a/lib/ex_gram/dsl.ex
+++ b/lib/ex_gram/dsl.ex
@@ -214,7 +214,7 @@ defmodule ExGram.Dsl do
 
   defp send_all_answers([answer | answers], name, msg, responses) do
     error = %ExGram.Error{
-      code: :unknonwn_answer,
+      code: :unknown_answer,
       message: "Unknown answer: #{inspect(answer)}",
       metadata: %{answer: answer}
     }

--- a/lib/ex_gram/encoder.ex
+++ b/lib/ex_gram/encoder.ex
@@ -18,7 +18,7 @@ defmodule ExGram.Encoder do
     This will reload the ExGram.Encoder.Engine module with the engine selected.
 
     With this we allow to define dynamically the engine backend while not having
-    to read it from the Application everytime.
+    to read it from the Application every time.
     """
 
     def compile(engine) do

--- a/lib/ex_gram/macros/executer.ex
+++ b/lib/ex_gram/macros/executer.ex
@@ -95,7 +95,7 @@ defmodule ExGram.Macros.Executer do
   defp to_size_string(false), do: "false"
   defp to_size_string(x) when is_binary(x), do: x
   defp to_size_string(x) when is_integer(x), do: Integer.to_string(x)
-  # This is usefull to encode automatically
+  # This is useful to encode automatically
   defp to_size_string(x) when is_map(x), do: encode(x)
   defp to_size_string(_), do: raise("Not sizable!")
 

--- a/lib/ex_gram/updates/polling.ex
+++ b/lib/ex_gram/updates/polling.ex
@@ -34,8 +34,8 @@ defmodule ExGram.Updates.Polling do
     {:noreply, {pid, token, nid}, @polling_timeout}
   end
 
-  def handle_info(unknonwn_message, state) do
-    Logger.debug("Polling updates received an unknown message #{inspect(unknonwn_message)}")
+  def handle_info(unknown_message, state) do
+    Logger.debug("Polling updates received an unknown message #{inspect(unknown_message)}")
 
     {:noreply, state, @polling_timeout}
   end


### PR DESCRIPTION
Found via `codespell -S deps -L splitted,childrens,everytime`