### PR TITLE
Enable sending file contents in editMessageMedia

### DIFF
--- a/lib/ex_gram.ex
+++ b/lib/ex_gram.ex
@@ -1043,6 +1043,7 @@ defmodule ExGram do
       {message_id, [:integer], :optional},
       {inline_message_id, [:string], :optional},
       {media, [InputMedia]},
+      {file, [:file], :optional},
       {reply_markup, [InlineKeyboardMarkup], :optional}
     ],
     ExGram.Model.Message,


### PR DESCRIPTION
Like this: `ExGram.editMessageMedia(%InputMedia{type: "photo", media: "attach://file"}, file: {:file_contents, <<>>, "img.gif"}, ...)`

It would be nice to be able to do `ExGram.editMessageMedia(%InputMedia{type: "photo", media: {:file_contents, <<>>, "img.gif"}}, ...)` finally