### PR TITLE
Add optional init callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,30 @@ This are the type of tuples that `handle/2` can receive as first parameter:
   - `{:message, message}` → This will match any message that does not fit with the ones described above
   - `{:update, update}` → This tuple will match as a default handle
 
+### Execute code on initialization
+
+The bots have an optional callback that will be executed *before* starting to consume messages. This method can be used to initialize things before starting the bot, for example setting the bot's description or name.
+
+The callback is `init/1`, the parameter is a keyword list with two values, `:bot` which is the bot's name, and `:token` with the token used when starting the bot. Either of this can be used when calling `ExGram` methods.
+
+Example of usage:
+
+``` elixir
+defmodule MyBot.Bot do
+  @bot :my_bot
+
+  use ExGram.Bot, name: @bot
+
+  def init(opts) do
+    ExGram.set_my_description!(description: "This is my description", bot: opts[:bot]) # with :bot
+    ExGram.set_my_name!(name: "My Bot", token: opts[:token]) # with :token
+    :ok
+  end
+
+  # ...
+end
+```
+
 ### Sending files
 
 `ExGram` lets you send files by id (this means using files already uploaded to Telegram servers), providing a local path, or with the content directly. Some examples of this methods for sending files:

--- a/lib/ex_gram/bot.ex
+++ b/lib/ex_gram/bot.ex
@@ -82,6 +82,12 @@ defmodule ExGram.Bot do
         raise message
       end
 
+      @type init_opts :: [bot: atom() | String.t(), token: String.t()]
+      @spec init(init_opts) :: :ok
+      def init(_opts) do
+        :ok
+      end
+
       def message(from, message) do
         GenServer.call(name(), {:message, from, message})
       end
@@ -98,6 +104,7 @@ defmodule ExGram.Bot do
       end
 
       defoverridable ExGram.Handler
+      defoverridable init: 1
     end
   end
 end

--- a/lib/ex_gram/bot/supervisor.ex
+++ b/lib/ex_gram/bot/supervisor.ex
@@ -54,6 +54,8 @@ defmodule ExGram.Bot.Supervisor do
 
     bot_info = maybe_fetch_bot(opts[:username], token)
 
+    module.init(bot: name, token: token)
+
     dispatcher_opts = %ExGram.Dispatcher{
       name: name,
       bot_info: bot_info,


### PR DESCRIPTION
Adds optional init callback to solve #123 

This is a new `init/1` method on the bot that will be called *just before* starting consuming messages.

The parameter of init is a keyword list with `:bot:` and `:token`

Example of usage:

``` elixir
defmodule MyBot.Bot do
  @bot :my_bot

  use ExGram.Bot, name: @bot

  def init(opts) do
    ExGram.get_me(bot: opts[:bot]) # with :bot
    ExGram.get_me(token: opts[:token]) # with :token
    :ok
  end

  # ...
end
```
