### PR TITLE
If :name is passed to the supervisor, that name is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix #131
 
 ## [0.41.0]
 - Update Telegram API to 6.8: https://core.telegram.org/bots/api#august-18-2023

--- a/lib/ex_gram/bot/supervisor.ex
+++ b/lib/ex_gram/bot/supervisor.ex
@@ -15,17 +15,16 @@ defmodule ExGram.Bot.Supervisor do
   end
 
   def start_link(opts, module) do
-    name = opts[:name] || module.name()
-    supervisor_name = Module.concat(module, Supervisor)
-    params = Keyword.merge(opts, name: name, module: module)
+    supervisor_name = opts[:name] || Module.concat(module, Supervisor)
+    params = Keyword.merge(opts, module: module)
     Supervisor.start_link(ExGram.Bot.Supervisor, params, name: supervisor_name)
   end
 
   def init(opts) do
     updates_method = Keyword.fetch!(opts, :method)
     token = Keyword.fetch!(opts, :token)
-    name = Keyword.fetch!(opts, :name)
     module = Keyword.fetch!(opts, :module)
+    name = module.name()
 
     {:ok, _} = Registry.register(Registry.ExGram, name, token)
 


### PR DESCRIPTION
Fixes #131 