### PR TITLE
Allow configuring polling and webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Added options on polling and webhook methods.
+WARNING: If you use custom module for method updates, the initial parameters passed to the `start_link/1` has changed. Before: `{:bot, pid, :token, token}` Now: `%{bot: pid, token: token}` + options configured on children setup
 
 ## [0.50.1]
 - Fix timeout on different Tesla adapters

--- a/README.md
+++ b/README.md
@@ -96,7 +96,42 @@ children = [
 ]
 ```
 
+### Polling mode
+
+The easiest way to get your bot runnig is using the Polling mode, it will use the method `getUpdates` on the telegram API to receive the new updates. You can read more about it here: https://core.telegram.org/bots/api#getting-updates
+
+Setting this mode is as easy as defining the mode and the token in your supervisor:
+
+``` elixir
+children = [
+  # ...
+  {MyBot, [method: :polling, token: "TOKEN"]}
+]
+```
+
+Additionally, you can configure the `getUpdates` call on the children options or on the application configuration.
+
+- In children options
+
+``` elixir
+children = [
+  # ...
+  {MyBot, [method: {:polling, allowed_updates: ["message", "edited_message"]}, token: "TOKEN"]}
+]
+```
+
+- In application configuration
+
+``` elixir
+config :ex_gram, :polling, allowed_updates: ["message", "edited_message"]
+```
+
+This configuration takes priority over the ones on the configuration files, but you can combine them, for example having a default `allowed_updates` in the application configuration and in some bots where you need other updates overide it on the children options.
+
+
 ### Webhook mode
+
+If you prefer to use webhook to have more performance receiving updates, you can use the provided Webhook mode.
 
 The provided Webhook adapter uses `Plug`, you will need to have that dependency in your application, and add it to your router, with basic Plug Router it would look something like this:
 
@@ -131,6 +166,20 @@ config :ex_gram, :webhook,
   secret_token: "some_super_secret_key",      # string
   url: "bot.example.com"                      # string (only domain name)
 ```
+
+You can also configure this options when starting inside the children options, you can configure it this way to ensure fine-grained setup per bot.
+
+Example:
+
+``` elixir
+webhook_options = [allowed_updates: ["message", "poll"], certificate: "priv/...", ...] # All options described before
+children = [
+  # We use a tuple instead of the atom
+  {MyBot, [method: {:webhook, webhook_options}, token: "TOKEN"]}
+]
+```
+
+This configuration takes priority over the ones on the configuration files, but you can combine them, for example configuring the `certificate`, `ip_address` and `url` in the config file and the `allowed_updates` and `drop_pending_updates` in the children options.
 
 For more information on each parameter, refer to this documentation: https://core.telegram.org/bots/api#setwebhook
 

--- a/lib/ex_gram/updates/noup.ex
+++ b/lib/ex_gram/updates/noup.ex
@@ -6,7 +6,7 @@ defmodule ExGram.Updates.Noup do
   use GenServer
   require Logger
 
-  def start_link({:bot, pid, :token, token}) do
+  def start_link(%{bot: pid, token: token}) do
     Logger.debug("Start NO Updates worker")
     GenServer.start_link(__MODULE__, {:ok, pid, token})
   end

--- a/lib/ex_gram/updates/polling.ex
+++ b/lib/ex_gram/updates/polling.ex
@@ -8,30 +8,33 @@ defmodule ExGram.Updates.Polling do
 
   @polling_timeout 100
 
-  def start_link({:bot, pid, :token, token}) do
+  def start_link(%{bot: pid, token: token} = opts) do
+    opts = Map.drop(opts, [:bot, :token])
     # Logger.debug "START WORKER"
-    GenServer.start_link(__MODULE__, {:ok, pid, token})
+    GenServer.start_link(__MODULE__, {:ok, pid, token, opts})
   end
 
-  def init({:ok, pid, token}) do
+  def init({:ok, pid, token, opts}) do
+    opts = ExGram.Config.get(:ex_gram, :polling, []) |> Keyword.merge(Keyword.new(opts))
+
     # Clean webhook
     ExGram.delete_webhook(token: token)
 
     Process.send_after(self(), {:fetch, :update_id}, @polling_timeout)
-    {:ok, {pid, token, -1}}
+    {:ok, {pid, token, -1, opts}}
   end
 
   def handle_cast({:fetch, :update_id} = m, state), do: handle_info(m, state)
 
   def handle_info(:timeout, state), do: handle_info({:fetch, :update_id}, state)
 
-  def handle_info({:fetch, :update_id}, {pid, token, uid}) do
-    updates = get_updates(token, uid)
+  def handle_info({:fetch, :update_id}, {pid, token, uid, opts}) do
+    updates = get_updates(token, uid, opts)
     send_updates(updates, pid)
 
     nid = next_pid(uid, updates)
 
-    {:noreply, {pid, token, nid}, @polling_timeout}
+    {:noreply, {pid, token, nid, opts}, @polling_timeout}
   end
 
   def handle_info(unknown_message, state) do
@@ -41,7 +44,9 @@ defmodule ExGram.Updates.Polling do
   end
 
   @default_opts [limit: 100, timeout: 50]
-  defp get_updates(token, uid, opts \\ []) do
+  defp get_updates(token, uid, opts) do
+    opts = Keyword.take(opts, [:allowed_updates])
+
     opts =
       @default_opts
       |> Keyword.merge(opts)

--- a/lib/ex_gram/updates/test.ex
+++ b/lib/ex_gram/updates/test.ex
@@ -7,7 +7,7 @@ defmodule ExGram.Updates.Test do
 
   defstruct [:pid, :token]
 
-  def start_link({:bot, pid, :token, token}) do
+  def start_link(%{bot: pid, token: token}) do
     GenServer.start_link(__MODULE__, {:ok, pid, token})
   end
 


### PR DESCRIPTION
Fixes #139 

Added optional configuration for polling updates, in two different ways:

- In children options

``` elixir
children = [
  # ...
  {MyBot, [method: {:polling, allowed_updates: ["message", "edited_message"]}, token: "TOKEN"]}
]
```

- In application configuration

``` elixir
config :ex_gram, :polling, allowed_updates: ["message", "edited_message"]
```
