### PR TITLE
Expose function to convert method responses to models

### DIFF
--- a/lib/ex_gram/cast.ex
+++ b/lib/ex_gram/cast.ex
@@ -1,0 +1,58 @@
+defmodule ExGram.Cast do
+  @moduledoc """
+  Helper module to convert plain values returned from Telegram to ExGram models.
+  """
+
+  @doc """
+  Converts the given plain value to ExGram models.
+
+    iex> ExGram.Cast.cast(%{message_id: 3, chat: %{id: 5}}, ExGram.Model.Message)
+    %ExGram.Model.Message{message_id: 3, chat: %ExGram.Model.Chat{id: 5}}
+  """
+  def cast(elem, type) do
+    process_type(elem, type)
+  end
+
+  defp process_type(nil, _), do: nil
+  defp process_type(elem, nil), do: elem
+
+  defp process_type(list, {:array, t}), do: Enum.map(list, &process_type(&1, t))
+  defp process_type(list, [t]), do: Enum.map(list, &process_type(&1, t))
+
+  defp process_type(elem, :integer), do: elem
+  defp process_type(elem, :string), do: elem
+  defp process_type(elem, true), do: elem
+
+  defp process_type(elem, t) when is_atom(t) do
+    if is_subtype?(t) do
+      apply_subtype(t, elem)
+    else
+      process_struct(t, elem)
+    end
+  end
+
+  defp process_type(elem, _t), do: elem
+
+  defp process_struct(t, elem) do
+    decoded_elem =
+      t.decode_as()
+      |> Map.from_struct()
+      |> Map.new(fn {k, v} ->
+        {k, process_type(elem[k], v)}
+      end)
+
+    struct(t, decoded_elem)
+  end
+
+  defp is_subtype?(t) do
+    ExGram.Model.Subtype.impl_for(struct(t, %{}))
+  end
+
+  defp apply_subtype(t, params) do
+    base = struct(t, %{})
+    selector = ExGram.Model.Subtype.selector_value(base, params)
+    subtype = ExGram.Model.Subtype.subtype(base, selector)
+
+    process_struct(subtype, params)
+  end
+end

--- a/lib/ex_gram/macros/executer.ex
+++ b/lib/ex_gram/macros/executer.ex
@@ -124,50 +124,7 @@ defmodule ExGram.Macros.Executer do
   defp clean_body(m), do: m
 
   defp process_result(result, type) do
-    process_type(result, type)
-  end
-
-  defp process_type(nil, _), do: nil
-  defp process_type(elem, nil), do: elem
-
-  defp process_type(list, {:array, t}), do: Enum.map(list, &process_type(&1, t))
-  defp process_type(list, [t]), do: Enum.map(list, &process_type(&1, t))
-
-  defp process_type(elem, :integer), do: elem
-  defp process_type(elem, :string), do: elem
-  defp process_type(elem, true), do: elem
-
-  defp process_type(elem, t) when is_atom(t) do
-    if is_subtype?(t) do
-      apply_subtype(t, elem)
-    else
-      process_struct(t, elem)
-    end
-  end
-
-  defp process_type(elem, _t), do: elem
-
-  defp process_struct(t, elem) do
-    decoded_elem =
-      t.decode_as()
-      |> Map.from_struct()
-      |> Map.new(fn {k, v} ->
-        {k, process_type(elem[k], v)}
-      end)
-
-    struct(t, decoded_elem)
-  end
-
-  defp is_subtype?(t) do
-    ExGram.Model.Subtype.impl_for(struct(t, %{}))
-  end
-
-  defp apply_subtype(t, params) do
-    base = struct(t, %{})
-    selector = ExGram.Model.Subtype.selector_value(base, params)
-    subtype = ExGram.Model.Subtype.subtype(base, selector)
-
-    process_struct(subtype, params)
+    ExGram.Cast.cast(result, type)
   end
 
   defp create_multipart(body, []), do: body

--- a/lib/ex_gram/plug.ex
+++ b/lib/ex_gram/plug.ex
@@ -43,8 +43,8 @@ if Code.ensure_loaded?(Plug) do
     defp handle_update(conn, {:ok, update}) do
       token_hash = token_hash(conn.path_info)
 
-      ExGram.Model.Update
-      |> struct(update)
+      update
+      |> ExGram.Cast.cast(ExGram.Model.Update)
       |> ExGram.Updates.Webhook.update(token_hash)
 
       {200, %{ok: true}}

--- a/test/ex_gram/cast_test.exs
+++ b/test/ex_gram/cast_test.exs
@@ -1,0 +1,5 @@
+defmodule ExGram.CastTest do
+  use ExUnit.Case, async: true
+
+  doctest ExGram.Cast
+end


### PR DESCRIPTION
I want to store messages as JSON in a database and then be able to convert the JSON back to the Message struct for easier  usage.

Instead of duplicating the logic, I thought it was best to make the function public. It also has the benefit of allowing us to use it for webhook updates. It was a suprise when switching from polling to webhooks that the values of the update weren't structs.

I'm not completely sold on the name, so let me know if you want me to change it to something else.