### PR TITLE
Add ability to configure Tesla logging via ExGram config

### DIFF
--- a/lib/ex_gram/adapter/tesla.ex
+++ b/lib/ex_gram/adapter/tesla.ex
@@ -14,7 +14,7 @@ if Code.ensure_loaded?(Tesla) do
 
     plug(Tesla.Middleware.BaseUrl, ExGram.Config.get(:ex_gram, :base_url, @base_url))
     plug(Tesla.Middleware.Headers, [{"Content-Type", "application/json"}])
-    plug(Tesla.Middleware.Logger, log_level: :info)
+    plug(Tesla.Middleware.Logger, ExGram.Config.get(:ex_gram, Tesla.Middleware.Logger, log_level: :info))
 
     plug(
       Tesla.Middleware.JSON,


### PR DESCRIPTION
Make possible to configure Tesla logger via Mix config files.

Example of how to configure it:
```elixir
config :ex_gram, Tesla.Middleware.Logger,
  log_level: :debug
```

Note that you may need to run `mix deps.compile ex_gram --force` after this config change.


**Alternative option** is to skip this override on ExGram side and allow user to configure it via `Tesla.Middleware.Logger` config (which in some cases may be less flexible for a user).