### PR TITLE
Allow optional webhook path

### DIFF
--- a/lib/ex_gram/plug.ex
+++ b/lib/ex_gram/plug.ex
@@ -14,7 +14,7 @@ if Code.ensure_loaded?(Plug) do
 
     @impl true
     def call(%Conn{method: "POST"} = conn, _) do
-      if "telegram" in conn.path_info do
+      if webhook_path_match?(conn) do
         handle_update(conn)
       else
         conn
@@ -81,6 +81,11 @@ if Code.ensure_loaded?(Plug) do
         {secret_token, config_token} when secret_token == config_token ->
           :ok
       end
+    end
+
+    defp webhook_path_match?(conn) do
+      webhook_path = ExGram.Config.get(:ex_gram, :webhook)[:webhook_path] || "telegram"
+      length(conn.path_info) == 2 && Enum.at(conn.path_info, 0) == webhook_path
     end
 
     defp token_hash([path]) when is_binary(path), do: path

--- a/lib/ex_gram/updates/webhook.ex
+++ b/lib/ex_gram/updates/webhook.ex
@@ -72,10 +72,12 @@ defmodule ExGram.Updates.Webhook do
     config = :ex_gram |> ExGram.Config.get(:webhook, []) |> Keyword.merge(opts)
     params = webhook_params(config)
 
+    webhook_path = Keyword.get(opts, :webhook_path, "telegram")
+
     case valid_url(config[:url]) do
       {:ok, webhook_url} ->
         params = Keyword.put(params, :token, token)
-        url = "#{webhook_url}/telegram/#{token_hash(token)}"
+        url = "#{webhook_url}/#{webhook_path}/#{token_hash(token)}"
         {:ok, true} = ExGram.set_webhook(url, params)
 
       {:error, error} ->


### PR DESCRIPTION
## Propositions
1. Enable a different path for the webhook
2. Tighter check for the webhook path in the plug (should match exactly)