### PR TITLE
Fix: Only reload JSON engine of configuration is set

### DIFF
--- a/lib/ex_gram.ex
+++ b/lib/ex_gram.ex
@@ -26,8 +26,9 @@ defmodule ExGram do
   end
 
   defp reload_engine do
-    engine = Application.get_env(:ex_gram, :json_engine)
-    ExGram.Encoder.EngineCompiler.compile(engine)
+    if engine = Application.get_env(:ex_gram, :json_engine) do
+      ExGram.Encoder.EngineCompiler.compile(engine)
+    end
   end
 
   def test_environment? do


### PR DESCRIPTION
After updating to 0.55 the application wouldn't run because the adapter would try to run `nil.encode!/2`. Turns out, the main supervisor is always reloading the JSON encoder module even if no engine is set in the `ex_gram` configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing or unset JSON engine configuration to prevent unnecessary operations and potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->