### PR TITLE
Fix docs source_ref to point to the correct tag

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -72,7 +72,7 @@ defmodule ExGram.Mixfile do
   defp docs do
     [
       main: "readme",
-      source_ref: "v#{@version}",
+      source_ref: @version,
       source_url: @source_url,
       skip_undefined_reference_warnings_on: ["CHANGELOG.md"],
       extras: ["README.md", "CHANGELOG.md"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation links to reference the version number without a leading "v" character.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->