### PR TITLE
Fix middleware_halted check

### DIFF
--- a/lib/ex_gram/dispatcher.ex
+++ b/lib/ex_gram/dispatcher.ex
@@ -88,7 +88,7 @@ defmodule ExGram.Dispatcher do
     cnt = %Cnt{default_context(state) | update: update}
     cnt = apply_middlewares(cnt)
 
-    unless cnt.halted do
+    unless cnt.halted || cnt.middleware_halted do
       info = extract_info(cnt)
       spawn(fn -> call_handler(info, cnt, state) end)
     end


### PR DESCRIPTION
It would be nice in a middleware to stop a request based on conditions. I found this function which mark the context as halted in a middleware:
```elixir
def halt(%ExGram.Cnt{} = cnt) do
    %{cnt | middleware_halted: true}
end
```

So i would expect the request to be halted, but it looks like this flag is not checked anywhere. The changes implement the check alongside the "halted" flag 