### PR TITLE
Add guides for Router and FSM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ erl_crash.dump
 
 /priv/plts/*.plt
 /priv/plts/*.plt.hash
+.dexter*

--- a/README.md
+++ b/README.md
@@ -238,13 +238,18 @@ See the [Sending Messages](guides/sending-messages.md) guide for a complete refe
 - [Handling Updates](guides/handling-updates.md) - Process commands, messages, and other updates
 - [Sending Messages](guides/sending-messages.md) - DSL philosophy and response building
 - [Define commands](guides/commands.md) - Clearly define you bot's commands, with options for different scopes and languages
+
+### Intermediate
+
+- [Router](guides/router.md) - Declarative routing DSL for organizing complex bots
+- [FSM](guides/fsm.md) - Finite state machine conversation flows
+- [Polling and Webhooks](guides/polling-and-webhooks.md) - Configure update methods
 - [Message Entities](guides/message-entities.md) - Format messages without dealing with MarkdownV2 or HTML
 - [Middlewares](guides/middlewares.md) - Add preprocessing logic
+- [Low-Level API](guides/low-level-api.md) - Direct API calls for complex scenarios
 
 ### Advanced
 
-- [Polling and Webhooks](guides/polling-and-webhooks.md) - Configure update methods
-- [Low-Level API](guides/low-level-api.md) - Direct API calls for complex scenarios
 - [Multiple Bots](guides/multiple-bots.md) - Run multiple bots in one application
 - [Bot Init Hooks](guides/bot-init-hooks.md) - Run custom code during bot startup
 - [Testing](guides/testing.md) - Test your bots
@@ -257,6 +262,13 @@ See the [Sending Messages](guides/sending-messages.md) guide for a complete refe
 
 - [Cheatsheet](guides/cheatsheet.md) - Quick reference for common patterns
 - [HexDocs](https://hexdocs.pm/ex_gram) - Complete API documentation
+
+## Ecosystem
+
+Companion libraries that extend ExGram, if you have a library that extends ExGram feel free to open a conversation to add it here:
+
+- **[ExGram Router](https://hex.pm/packages/ex_gram_router)** — A declarative routing DSL that replaces `handle/2` pattern-match chains with composable `scope`/`filter`/`handle` blocks. Includes built-in filters for commands, text, callback queries, and more, plus mix tasks for inspecting your bot's route tree. See the [Router guide](guides/router.md).
+- **[ExGram FSM](https://hex.pm/packages/ex_gram_fsm)** — Finite state machine conversation management with named flows, validated transitions, pluggable storage backends, and automatic ExGram.Router integration. See the [FSM guide](guides/fsm.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ See the [Sending Messages](guides/sending-messages.md) guide for a complete refe
 
 ## Ecosystem
 
-Companion libraries that extend ExGram, if you have a library that extends ExGram feel free to open a conversation to add it here:
+Companion libraries that extend ExGram. If you have a library that extends ExGram feel free to open a discussion to add it here:
 
 - **[ExGram Router](https://hex.pm/packages/ex_gram_router)** — A declarative routing DSL that replaces `handle/2` pattern-match chains with composable `scope`/`filter`/`handle` blocks. Includes built-in filters for commands, text, callback queries, and more, plus mix tasks for inspecting your bot's route tree. See the [Router guide](guides/router.md).
 - **[ExGram FSM](https://hex.pm/packages/ex_gram_fsm)** — Finite state machine conversation management with named flows, validated transitions, pluggable storage backends, and automatic ExGram.Router integration. See the [FSM guide](guides/fsm.md).

--- a/guides/fsm.md
+++ b/guides/fsm.md
@@ -1,0 +1,319 @@
+# FSM (Finite State Machine)
+
+Many bots need multi-step conversation flows: registration forms, settings wizards, onboarding sequences. You can model these with pattern matching on `context.extra`, but as flows multiply, managing state transitions, validation, and cleanup becomes tedious and error-prone.
+
+[ExGram.FSM](https://hex.pm/packages/ex_gram_fsm) provides structured conversation state management with:
+
+- **Named flows** with explicitly declared states and valid transitions
+- **Runtime transition validation** — catch illegal state jumps early
+- **Pluggable storage** — ETS for development, bring your own backend for production
+- **Key adapters** — scope state per-user, per-chat, or per-topic
+- **Router integration** — automatic `:fsm_flow` and `:fsm_state` filter aliases when used with [ExGram.Router](router.md)
+
+## Installation
+
+Add `ex_gram_fsm` to your dependencies:
+
+```elixir
+# mix.exs
+def deps do
+  [
+    {:ex_gram, "~> 0.65"},
+    {:ex_gram_fsm, "~> 0.1.0"},
+    {:jason, ">= 1.0.0"},
+    {:req, "~> 0.5"}
+  ]
+end
+```
+
+If you're also using [ExGram.Router](router.md) (recommended), add it too:
+
+```elixir
+def deps do
+  [
+    {:ex_gram, "~> 0.65"},
+    {:ex_gram_router, "~> 0.1.0"},
+    {:ex_gram_fsm, "~> 0.1.0"},
+    {:jason, ">= 1.0.0"},
+    {:req, "~> 0.5"}
+  ]
+end
+```
+
+## Defining Flows
+
+Each conversation flow is a module that declares its states and allowed transitions:
+
+```elixir
+defmodule MyBot.RegistrationFlow do
+  use ExGram.FSM.Flow, name: :registration
+
+  defstates do
+    state :get_name,  to: [:get_email]
+    state :get_email, to: [:done]
+    state :done,      to: []
+  end
+
+  def default_state, do: :get_name
+end
+```
+
+- **`name:`** — Identifies this flow (used in `start_flow/2` and filters)
+- **`defstates`** — Declares valid states and where each can transition to
+- **`default_state/0`** — The initial state when the flow starts
+
+The transition graph is validated at compile time and enforced at runtime. If you try `transition(context, :done)` from `:get_name`, the configured policy kicks in (raise, log, or ignore).
+
+## Flow Lifecycle
+
+A flow goes through four stages:
+
+1. **Start** — `start_flow(context, :registration)` activates the flow, sets the default state, and clears any previous data.
+2. **Transition** — `transition(context, :get_email)` moves to the next state. The transition is validated against the flow's declared graph.
+3. **Accumulate** — `update_data(context, %{name: name})` merges data into the flow's persistent data map. Collect form fields step by step.
+4. **End** — `clear_flow(context)` resets everything: no active flow, no state, no data.
+
+## Basic Example (Without Router)
+
+You can use ExGram.FSM with plain `handle/2` pattern matching:
+
+```elixir
+defmodule MyBot do
+  use ExGram.Bot, name: :my_bot, setup_commands: true
+  use ExGram.FSM,
+    storage: ExGram.FSM.Storage.ETS,
+    flows: [MyBot.RegistrationFlow]
+
+  command("register", description: "Start registration")
+
+  def handle({:command, :register, _}, context) do
+    context
+    |> start_flow(:registration)
+    |> answer("What's your name?")
+  end
+
+  def handle(
+        {:text, name, _},
+        %{extra: %{fsm: %ExGram.FSM.State{flow: :registration, state: :get_name}}} = context
+      ) do
+    context
+    |> update_data(%{name: name})
+    |> transition(:get_email)
+    |> answer("Got it, #{name}! What's your email?")
+  end
+
+  def handle(
+        {:text, email, _},
+        %{extra: %{fsm: %ExGram.FSM.State{flow: :registration, state: :get_email}}} = context
+      ) do
+    %{name: name} = get_data(context)
+
+    context
+    |> update_data(%{email: email})
+    |> clear_flow()
+    |> answer("Done! Welcome, #{name} (#{email}).")
+  end
+
+  def handle(_, context), do: context
+end
+```
+
+This works fine, but the pattern matching on `context.extra.fsm` is verbose. With [ExGram.Router](router.md), you get dedicated filter aliases.
+
+## With ExGram.Router (Recommended)
+
+When `use ExGram.Router` is present in the same module, `use ExGram.FSM` automatically registers three filter aliases: `:fsm_flow`, `:fsm_state`, and `:fsm_in_flow`.
+
+> **Important:** `use ExGram.Router` must come *before* `use ExGram.FSM`.
+
+```elixir
+defmodule MyBot do
+  use ExGram.Bot, name: :my_bot, setup_commands: true
+  use ExGram.Router
+  use ExGram.FSM,
+    storage: ExGram.FSM.Storage.ETS,
+    flows: [MyBot.RegistrationFlow]
+
+  command("register", description: "Start registration")
+
+  scope do
+    filter :command, :register
+    handle &MyBot.Handlers.start_registration/1
+  end
+
+  scope do
+    filter :fsm_flow, :registration
+
+    scope do
+      filter :fsm_state, :get_name
+      filter :text
+      handle &MyBot.Handlers.got_name/1
+    end
+
+    scope do
+      filter :fsm_state, :get_email
+      filter :text
+      handle &MyBot.Handlers.got_email/1
+    end
+  end
+
+  scope do
+    handle &MyBot.Handlers.fallback/1
+  end
+end
+```
+
+```elixir
+defmodule MyBot.Handlers do
+  import ExGram.Dsl
+
+  def start_registration(context) do
+    context
+    |> start_flow(:registration)
+    |> answer("What's your name?")
+  end
+
+  def got_name(context) do
+    name = context.update.message.text
+
+    context
+    |> update_data(%{name: name})
+    |> transition(:get_email)
+    |> answer("Got it, #{name}! What's your email?")
+  end
+
+  def got_email(context) do
+    %{name: name} = get_data(context)
+    email = context.update.message.text
+
+    context
+    |> update_data(%{email: email})
+    |> clear_flow()
+    |> answer("Registered! Welcome, #{name} (#{email}).")
+  end
+
+  def fallback(context), do: context
+end
+```
+
+The routing structure makes the flow visible at a glance: the outer scope guards on `:fsm_flow`, and each inner scope matches a specific step plus the expected input type.
+
+### FSM Filter Reference
+
+| Filter | Options | Matches when… |
+|--------|---------|---------------|
+| `:fsm_flow` | atom or `nil` | Active flow matches the given name (or `nil` for no active flow) |
+| `:fsm_state` | atom | Current state matches the given atom |
+| `:fsm_state` | `{key, value}` | `fsm_data[key] == value` |
+| `:fsm_in_flow` | (none) | Any flow is active |
+
+## Helper Functions
+
+`use ExGram.FSM` imports these functions into your bot module (and they're available in handler modules that import from the bot):
+
+| Function | Description |
+|----------|-------------|
+| `start_flow(context, flow_name)` | Start a flow — sets default state and clears data |
+| `transition(context, state)` | Move to the next state (validated) |
+| `set_state(context, state)` | Force-set state, bypassing validation |
+| `set_state(context, flow, state)` | Force-set flow + state (escape hatch) |
+| `get_flow(context)` | Current active flow name, or `nil` |
+| `get_state(context)` | Current step within the active flow, or `nil` |
+| `get_data(context)` | FSM data map (never `nil`) |
+| `update_data(context, map)` | Merge a map into the FSM data |
+| `clear_flow(context)` | Reset: no flow, no state, no data |
+
+All helpers take and return `ExGram.Cnt.t()`, so they work seamlessly in pipelines.
+
+### `transition/2` vs `set_state/2`
+
+- **`transition/2`** validates the move against the flow's declared transitions and applies the `on_invalid_transition` policy if it's not allowed. This is the normal path — use it in your handlers.
+- **`set_state/2`** and **`set_state/3`** bypass validation entirely. Use them for admin tools, recovery, or testing.
+
+## Transition Policies
+
+Configure what happens when an invalid transition is attempted:
+
+```elixir
+use ExGram.FSM,
+  storage: ExGram.FSM.Storage.ETS,
+  flows: [MyBot.RegistrationFlow],
+  on_invalid_transition: :log  # or :raise, :ignore, {Module, :function}
+```
+
+| Policy | Behavior |
+|--------|----------|
+| `:raise` (default) | Raises `ExGram.FSM.TransitionError` |
+| `:log` | Logs a warning, returns context unchanged |
+| `:ignore` | Silent no-op, returns context unchanged |
+| `{Module, :function}` | Calls `Module.function(context, from, to)` for custom handling |
+
+## Storage Backends
+
+The default backend is `ExGram.FSM.Storage.ETS` — in-memory, single-node, and **state is lost on restart**. This is fine for development and simple bots.
+
+For production, implement the `ExGram.FSM.Storage` behaviour:
+
+```elixir
+defmodule MyBot.RedisStorage do
+  @behaviour ExGram.FSM.Storage
+
+  @impl true
+  def init(bot_name, _opts), do: :ok
+
+  @impl true
+  def get_state(bot_name, key), do: # read from Redis
+
+  @impl true
+  def set_state(bot_name, key, %ExGram.FSM.State{} = state), do: # write
+
+  @impl true
+  def get_data(bot_name, key), do: # read data
+
+  @impl true
+  def set_data(bot_name, key, data), do: # write data
+
+  @impl true
+  def update_data(bot_name, key, new_data), do: # merge and write
+
+  @impl true
+  def clear(bot_name, key), do: # delete
+end
+```
+
+Use it:
+
+```elixir
+use ExGram.FSM, storage: MyBot.RedisStorage, flows: [...]
+```
+
+Storage is bot-scoped: the `bot_name` argument lets a single backend serve multiple bots without key collisions. The ETS implementation creates one named table per bot.
+
+## Key Adapters
+
+Key adapters control how FSM state is scoped — who shares state with whom:
+
+| Adapter | Key | Use case |
+|---------|-----|----------|
+| `ExGram.FSM.Key.ChatUser` (default) | `{chat_id, user_id}` | Each user has independent state per chat |
+| `ExGram.FSM.Key.User` | `{user_id}` | Same state across all chats (DMs, groups) |
+| `ExGram.FSM.Key.Chat` | `{chat_id}` | Shared state for all users in a chat |
+| `ExGram.FSM.Key.ChatTopic` | `{chat_id, thread_id}` | Per forum topic, shared |
+| `ExGram.FSM.Key.ChatTopicUser` | `{chat_id, thread_id, user_id}` | Per-user per forum topic |
+
+```elixir
+# User-scoped: state follows the user everywhere
+use ExGram.FSM, key: ExGram.FSM.Key.User, flows: [...]
+
+# Chat-scoped: shared state, e.g. group game sessions
+use ExGram.FSM, key: ExGram.FSM.Key.Chat, flows: [...]
+```
+
+You can also implement `ExGram.FSM.Key` to define your own scoping strategy.
+
+## Next Steps
+
+- [Router](router.md) - Declarative routing DSL (pairs perfectly with FSM)
+- [Middlewares](middlewares.md) - Enrich context before routing and FSM
+- [Handling Updates](handling-updates.md) - Understand update types
+- [Testing](testing.md) - Test your bot end-to-end

--- a/guides/fsm.md
+++ b/guides/fsm.md
@@ -10,6 +10,8 @@ Many bots need multi-step conversation flows: registration forms, settings wizar
 - **Key adapters** — scope state per-user, per-chat, or per-topic
 - **Router integration** — automatic `:fsm_flow` and `:fsm_state` filter aliases when used with [ExGram.Router](router.md)
 
+> This guide covers the most common usage. For the full API reference and advanced options, see the [ExGram.FSM HexDocs](https://hexdocs.pm/ex_gram_fsm).
+
 ## Installation
 
 Add `ex_gram_fsm` to your dependencies:
@@ -147,13 +149,13 @@ defmodule MyBot do
     scope do
       filter :fsm_state, :get_name
       filter :text
-      handle &MyBot.Handlers.got_name/1
+      handle &MyBot.Handlers.got_name/2
     end
 
     scope do
       filter :fsm_state, :get_email
       filter :text
-      handle &MyBot.Handlers.got_email/1
+      handle &MyBot.Handlers.got_email/2
     end
   end
 
@@ -173,18 +175,15 @@ defmodule MyBot.Handlers do
     |> answer("What's your name?")
   end
 
-  def got_name(context) do
-    name = context.update.message.text
-
+  def got_name({:text, name, _}, context) do
     context
     |> update_data(%{name: name})
     |> transition(:get_email)
     |> answer("Got it, #{name}! What's your email?")
   end
 
-  def got_email(context) do
+  def got_email({:text, email, _}, context) do
     %{name: name} = get_data(context)
-    email = context.update.message.text
 
     context
     |> update_data(%{email: email})

--- a/guides/handling-updates.md
+++ b/guides/handling-updates.md
@@ -347,9 +347,18 @@ def handle({:callback_query, %{from: user, data: data}}, context) do
 end
 ```
 
+## Beyond `handle/2`
+
+As your bot grows, a single `handle/2` function with many pattern-match clauses can become hard to navigate. Two companion libraries can help:
+
+- **[ExGram.Router](router.md)** — Replace `handle/2` clauses with a declarative `scope`/`filter`/`handle` DSL. The router dispatches updates based on composable filters (commands, text, callback queries, etc.) and lets you nest scopes for hierarchical routing. This is the recommended way to organize larger bots.
+- **[ExGram.FSM](fsm.md)** — Manage multi-step conversation flows (registration, onboarding, wizards) with named flows, validated state transitions, and pluggable storage. Integrates seamlessly with the router via automatic filter aliases.
+
 ## Next Steps
 
 - [Sending Messages](sending-messages.md) - Learn the DSL for building responses
+- [Router](router.md) - Declarative routing for complex bots
+- [FSM](fsm.md) - Finite state machine conversation flows
 - [Message Entities](message-entities.md) - Format messages without Markdown or HTML
 - [Middlewares](middlewares.md) - Add preprocessing logic to your bot
 - [Low-Level API](low-level-api.md) - Direct API calls for complex scenarios

--- a/guides/router.md
+++ b/guides/router.md
@@ -87,12 +87,33 @@ defmodule MyBot.Handlers do
 
   def start(ctx), do: answer(ctx, "Welcome!")
   def help(ctx),  do: answer(ctx, "Here is what I can do…")
-  def echo(ctx),  do: answer(ctx, "You said something!")
+
+  # 2-arity: receives (update_info, context) to extract the message text directly
+  def echo({:text, text, _msg}, ctx), do: answer(ctx, text)
+
   def fallback(ctx), do: ctx
 end
 ```
 
 Notice that handlers live in their own module. This is optional — you can keep them inline — but separating handlers from routing keeps both sides clean as the bot grows.
+
+## Handler Arities
+
+Handlers can be **1-arity** or **2-arity**:
+
+```elixir
+# 1-arity: receives only context
+def start(context) do
+  answer(context, "Welcome!")
+end
+
+# 2-arity: receives (update_info, context)
+def echo({:text, text, _msg}, context) do
+  answer(context, text)
+end
+```
+
+The router detects the arity at compile time. Use 2-arity when you need to extract data from the parsed update tuple directly.
 
 ### How dispatch works
 
@@ -196,24 +217,6 @@ Propagation stacks across nesting levels, so you can model arbitrary callback da
 ## Custom Filters
 
 When the built-in filters aren't enough, you can implement the `ExGram.Router.Filter` behaviour to encode any runtime predicate - user roles, conversation state, feature flags, and more. See the [Custom Filters section in the ExGram.Router documentation](https://github.com/rockneurotiko/ex_gram_router#custom-filters) for the full guide including examples and alias registration.
-
-## Handler Arities
-
-Handlers can be **1-arity** or **2-arity**:
-
-```elixir
-# 1-arity: receives only context
-def start(context) do
-  answer(context, "Welcome!")
-end
-
-# 2-arity: receives (update_info, context)
-def echo({:command, _name, %{text: text}}, context) do
-  answer(context, text)
-end
-```
-
-The router detects the arity at compile time. Use 2-arity when you need to extract data from the parsed update tuple directly.
 
 ## Inspecting Routes
 

--- a/guides/router.md
+++ b/guides/router.md
@@ -1,0 +1,330 @@
+# Router
+
+As your bot grows, the `handle/2` function can become a long chain of pattern-match clauses — commands, callback queries, text handlers, inline queries, all interleaved in a single module. When you add conversation flows or role-based access, the clause count explodes and it becomes hard to see the overall structure at a glance.
+
+[ExGram.Router](https://hex.pm/packages/ex_gram_router) replaces those hand-written clauses with a declarative **scope / filter / handle** DSL. You describe *what* each handler should match, and the router takes care of dispatching. Everything compiles down to a standard `handle/2` function, so the rest of ExGram (middlewares, DSL, testing) works exactly the same.
+
+## Installation
+
+Add `ex_gram_router` to your dependencies:
+
+```elixir
+# mix.exs
+def deps do
+  [
+    {:ex_gram, "~> 0.65"},
+    {:ex_gram_router, "~> 0.1.0"},
+    {:jason, ">= 1.0.0"},
+    {:req, "~> 0.5"}
+  ]
+end
+```
+
+Then add `:ex_gram_router` to the formatter deps alongside `:ex_gram`:
+
+```elixir
+# .formatter.exs
+[
+  import_deps: [:ex_gram, :ex_gram_router]
+]
+```
+
+## From `handle/2` to Scopes
+
+Here's a typical bot using plain `handle/2`:
+
+```elixir
+defmodule MyBot do
+  use ExGram.Bot, name: :my_bot, setup_commands: true
+
+  command("start", description: "Start the bot")
+  command("help",  description: "Show help")
+
+  def handle({:command, :start, _}, ctx), do: answer(ctx, "Welcome!")
+  def handle({:command, :help, _}, ctx),  do: answer(ctx, "Here is what I can do…")
+  def handle({:text, _, _}, ctx),         do: answer(ctx, "You said something!")
+  def handle(_, ctx),                     do: ctx
+end
+```
+
+The same bot with `ExGram.Router`:
+
+```elixir
+defmodule MyBot do
+  use ExGram.Bot, name: :my_bot, setup_commands: true
+  use ExGram.Router
+
+  command("start", description: "Start the bot")
+  command("help",  description: "Show help")
+
+  scope do
+    filter :command, :start
+    handle &MyBot.Handlers.start/1
+  end
+
+  scope do
+    filter :command, :help
+    handle &MyBot.Handlers.help/1
+  end
+
+  scope do
+    filter :text
+    handle &MyBot.Handlers.echo/1
+  end
+
+  # Catch-all fallback
+  scope do
+    handle &MyBot.Handlers.fallback/1
+  end
+end
+```
+
+```elixir
+defmodule MyBot.Handlers do
+  import ExGram.Dsl
+
+  def start(ctx), do: answer(ctx, "Welcome!")
+  def help(ctx),  do: answer(ctx, "Here is what I can do…")
+  def echo(ctx),  do: answer(ctx, "You said something!")
+  def fallback(ctx), do: ctx
+end
+```
+
+Notice that handlers live in their own module. This is optional — you can keep them inline — but separating handlers from routing keeps both sides clean as the bot grows.
+
+### How dispatch works
+
+1. Scopes are tried **top-to-bottom** in declaration order.
+2. All filters in a scope must pass (AND logic).
+3. The **first matching leaf** wins — its handler runs and dispatch stops.
+4. A scope with **no filters** matches everything, so a filter-less scope at the bottom acts as a fallback.
+
+## Built-in Filters
+
+The router ships with filters for the most common update types. Use them by alias name:
+
+```elixir
+# Commands
+filter :command              # any command
+filter :command, :start      # specific command
+
+# Text messages
+filter :text                 # any text
+filter :text, "hello"        # exact match
+filter :text, ~r/^\d+$/      # regex match
+filter :text, prefix: "!"    # starts with
+filter :text, contains: "hi" # contains substring
+
+# Callback queries
+filter :callback_query                    # any callback
+filter :callback_query, "confirm"         # exact data
+filter :callback_query, ~r/^page_\d+$/   # regex match
+filter :callback_query, prefix: "settings:" # prefix match
+
+# Inline queries
+filter :inline_query
+filter :inline_query, prefix: "@"
+
+# Media & other types
+filter :photo
+filter :document
+filter :location
+filter :sticker
+filter :voice
+filter :video
+filter :animation
+filter :audio
+filter :contact
+filter :poll
+filter :video_note
+filter :message    # any message-type update
+filter :regex      # any named regex match
+```
+
+Each filter alias maps to a module under `ExGram.Router.Filters.*`. You never need to reference them directly, but you can if you prefer.
+
+## Nested Scopes
+
+Scopes can be nested. A child scope only runs if its parent's filters already passed, so parent filters act as guards for all children:
+
+```elixir
+scope do
+  filter :callback_query, prefix: "settings:"
+
+  scope do
+    filter :callback_query, "settings:language"
+    handle &MyBot.Handlers.settings_language/1
+  end
+
+  scope do
+    filter :callback_query, "settings:timezone"
+    handle &MyBot.Handlers.settings_timezone/1
+  end
+end
+```
+
+This is especially useful for callback queries with hierarchical data patterns. Instead of repeating the prefix in every leaf, you filter it once at the parent level.
+
+### Prefix Propagation
+
+For deeply nested callback data, you can use `propagate: true` on a prefix filter. The matched prefix is stripped and child scopes match against the **remainder**:
+
+```elixir
+scope do
+  filter :callback_query, prefix: "proj:", propagate: true
+
+  scope do
+    filter :callback_query, "change"   # matches "proj:change"
+    handle &MyBot.Handlers.change_project/1
+  end
+
+  scope do
+    filter :callback_query, prefix: "settings:", propagate: true
+
+    scope do
+      filter :callback_query, "volume"   # matches "proj:settings:volume"
+      handle &MyBot.Handlers.volume/1
+    end
+  end
+end
+```
+
+Propagation stacks across nesting levels, so you can model arbitrary callback data hierarchies cleanly.
+
+## Custom Filters
+
+When the built-in filters aren't enough, implement the `ExGram.Router.Filter` behaviour:
+
+```elixir
+defmodule MyBot.Filters.AdminOnly do
+  @behaviour ExGram.Router.Filter
+
+  @impl true
+  def call(_update_info, context, _opts) do
+    Map.get(context.extra, :role) == :admin
+  end
+end
+```
+
+The `call/3` function receives the parsed update tuple, the context, and any options passed to the filter. Return `true` to pass, `false` to skip.
+
+> **Filters must be pure.** Never perform database queries, HTTP calls, or side effects inside a filter. If a filter needs external data (user roles, feature flags), load it once in a [middleware](middlewares.md) and store the result in `context.extra`.
+
+### Registering custom filter aliases
+
+Use `alias_filter` at the top of your bot module, or pass aliases as an option to `use ExGram.Router`:
+
+```elixir
+# Option 1: alias_filter macro
+alias_filter MyBot.Filters.AdminOnly, as: :admin
+
+scope do
+  filter :admin
+  handle &MyBot.Handlers.admin_panel/1
+end
+
+# Option 2: use option
+use ExGram.Router,
+  aliases: [
+    admin: MyBot.Filters.AdminOnly,
+    state: MyBot.Filters.State
+  ]
+```
+
+### Enrich filters with `scope_extra/2`
+
+Filters can optionally implement `scope_extra/2` to inject data into `context.extra` for child scopes. This avoids redundant lookups when a parent filter already computed or loaded something:
+
+```elixir
+defmodule MyBot.Filters.Project do
+  @behaviour ExGram.Router.Filter
+
+  @impl true
+  def call(_update_info, context, project_id) do
+    Map.get(context.extra, :project_id) == project_id
+  end
+
+  @impl true
+  def scope_extra(_context, project_id) do
+    %{project: MyBot.Projects.get!(project_id)}
+  end
+end
+```
+
+Child scopes of a scope using this filter will have `context.extra.project` available automatically.
+
+## Handler Arities
+
+Handlers can be **1-arity** or **2-arity**:
+
+```elixir
+# 1-arity: receives only context
+def start(context) do
+  answer(context, "Welcome!")
+end
+
+# 2-arity: receives (update_info, context)
+def echo({:command, _name, %{text: text}}, context) do
+  answer(context, text)
+end
+```
+
+The router detects the arity at compile time. Use 2-arity when you need to extract data from the parsed update tuple directly.
+
+## Inspecting Routes
+
+The router ships with two mix tasks for visualizing your bot's routing configuration:
+
+### `mix ex_gram.router.tree`
+
+Prints the full scope tree with indentation:
+
+```
+$ mix ex_gram.router.tree MyBot
+
+MyBot routing tree:
+├── scope
+│   ├── filters: [Command(:start)]
+│   └── handle: &MyBot.Handlers.start/1
+├── scope
+│   ├── filters: [Command(:help)]
+│   └── handle: &MyBot.Handlers.help/1
+└── scope
+    ├── filters: [CallbackQuery([prefix: "proj:"]) [propagate]]
+    ├── scope
+    │   ├── filters: [CallbackQuery("change")]
+    │   └── handle: &MyBot.Handlers.change_project/1
+    └── scope
+        ├── filters: [CallbackQuery("delete")]
+        └── handle: &MyBot.Handlers.delete_project/1
+```
+
+### `mix ex_gram.router.flat`
+
+Prints one line per handler with the full accumulated filter chain, similar to `mix phx.routes` in Phoenix:
+
+```
+$ mix ex_gram.router.flat MyBot
+
+MyBot handlers:
+MyBot.Handlers  start/1          filters: [Command(:start)]
+MyBot.Handlers  help/1           filters: [Command(:help)]
+MyBot.Handlers  change_project/1 filters: [CallbackQuery([prefix: "proj:"]) [propagate], CallbackQuery("change")]
+MyBot.Handlers  delete_project/1 filters: [CallbackQuery([prefix: "proj:"]) [propagate], CallbackQuery("delete")]
+MyBot.Handlers  fallback/1       filters: []
+```
+
+These are invaluable for debugging routing issues or onboarding new team members.
+
+## Testing
+
+The router generates a standard `handle/2` function, so testing works exactly like any other ExGram bot. Use `ExGram.Adapter.Test`, push updates, and assert on outgoing API calls. No special setup needed.
+
+See the [Testing](testing.md) guide for details.
+
+## Next Steps
+
+- [FSM](fsm.md) - Add finite state machine conversation flows (works great with the router)
+- [Middlewares](middlewares.md) - Enrich context with data your filters need
+- [Handling Updates](handling-updates.md) - Understand the update tuples that filters match against
+- [Cheatsheet](cheatsheet.md) - Quick reference for common patterns

--- a/guides/router.md
+++ b/guides/router.md
@@ -193,68 +193,7 @@ Propagation stacks across nesting levels, so you can model arbitrary callback da
 
 ## Custom Filters
 
-When the built-in filters aren't enough, implement the `ExGram.Router.Filter` behaviour:
-
-```elixir
-defmodule MyBot.Filters.AdminOnly do
-  @behaviour ExGram.Router.Filter
-
-  @impl true
-  def call(_update_info, context, _opts) do
-    Map.get(context.extra, :role) == :admin
-  end
-end
-```
-
-The `call/3` function receives the parsed update tuple, the context, and any options passed to the filter. Return `true` to pass, `false` to skip.
-
-> **Filters must be pure.** Never perform database queries, HTTP calls, or side effects inside a filter. If a filter needs external data (user roles, feature flags), load it once in a [middleware](middlewares.md) and store the result in `context.extra`.
-
-### Registering custom filter aliases
-
-Use `alias_filter` at the top of your bot module, or pass aliases as an option to `use ExGram.Router`:
-
-```elixir
-# Option 1: alias_filter macro
-alias_filter MyBot.Filters.AdminOnly, as: :admin
-
-scope do
-  filter :admin
-  handle &MyBot.Handlers.admin_panel/1
-end
-
-# Option 2: use option
-use ExGram.Router,
-  aliases: [
-    admin: MyBot.Filters.AdminOnly,
-    state: MyBot.Filters.State
-  ]
-```
-
-### Enrich filters with `scope_extra/2`
-
-Filters can optionally implement `scope_extra/2` to inject data into `context.extra` for child scopes. This avoids redundant lookups when a parent filter already computed or loaded something:
-
-```elixir
-defmodule MyBot.Filters.Project do
-  @behaviour ExGram.Router.Filter
-
-  @impl true
-  def call(_update_info, context, project_id) do
-    Map.get(context.extra, :project_id) == project_id
-  end
-
-  @impl true
-  def scope_extra(context, _project_id) do
-    # Reuse data already loaded by middleware
-    %{project: Map.get(context.extra, :project)}
-  end
-end
-```
-
-> **Note:** `scope_extra/2` runs on every dispatch, so it's usually better to load data in a [middleware](middlewares.md) and restructure it here rather than performing database queries or HTTP calls directly.
-
-Child scopes of a scope using this filter will have `context.extra.project` available automatically.
+When the built-in filters aren't enough, you can implement the `ExGram.Router.Filter` behaviour to encode any runtime predicate - user roles, conversation state, feature flags, and more. See the [Custom Filters section in the ExGram.Router documentation](https://github.com/rockneurotiko/ex_gram_router#custom-filters) for the full guide including examples and alias registration.
 
 ## Handler Arities
 

--- a/guides/router.md
+++ b/guides/router.md
@@ -4,6 +4,8 @@ As your bot grows, the `handle/2` function can become a long chain of pattern-ma
 
 [ExGram.Router](https://hex.pm/packages/ex_gram_router) replaces those hand-written clauses with a declarative **scope / filter / handle** DSL. You describe *what* each handler should match, and the router takes care of dispatching. Everything compiles down to a standard `handle/2` function, so the rest of ExGram (middlewares, DSL, testing) works exactly the same.
 
+> This guide covers the most common usage. For the full API reference and advanced options, see the [ExGram.Router HexDocs](https://hexdocs.pm/ex_gram_router).
+
 ## Installation
 
 Add `ex_gram_router` to your dependencies:

--- a/guides/router.md
+++ b/guides/router.md
@@ -71,7 +71,7 @@ defmodule MyBot do
 
   scope do
     filter :text
-    handle &MyBot.Handlers.echo/1
+    handle &MyBot.Handlers.echo/2
   end
 
   # Catch-all fallback

--- a/guides/router.md
+++ b/guides/router.md
@@ -245,11 +245,14 @@ defmodule MyBot.Filters.Project do
   end
 
   @impl true
-  def scope_extra(_context, project_id) do
-    %{project: MyBot.Projects.get!(project_id)}
+  def scope_extra(context, _project_id) do
+    # Reuse data already loaded by middleware
+    %{project: Map.get(context.extra, :project)}
   end
 end
 ```
+
+> **Note:** `scope_extra/2` runs on every dispatch, so it's usually better to load data in a [middleware](middlewares.md) and restructure it here rather than performing database queries or HTTP calls directly.
 
 Child scopes of a scope using this filter will have `context.extra.project` available automatically.
 

--- a/guides/router.md
+++ b/guides/router.md
@@ -279,7 +279,7 @@ The router ships with two mix tasks for visualizing your bot's routing configura
 
 Prints the full scope tree with indentation:
 
-```
+```text
 $ mix ex_gram.router.tree MyBot
 
 MyBot routing tree:
@@ -303,7 +303,7 @@ MyBot routing tree:
 
 Prints one line per handler with the full accumulated filter chain, similar to `mix phx.routes` in Phoenix:
 
-```
+```text
 $ mix ex_gram.router.flat MyBot
 
 MyBot handlers:

--- a/mix.exs
+++ b/mix.exs
@@ -119,7 +119,7 @@ defmodule ExGram.Mixfile do
     [
       Cheatsheet: "guides/cheatsheet.md",
       Basic: ~r/guides\/(installation|getting-started|handling-updates|commands|sending-messages)\.md/,
-      Intermediate: ~r/guides\/(polling-and-webhooks|message-entities|middlewares|low-level-api)\.md/,
+      Intermediate: ~r/guides\/(router|fsm|polling-and-webhooks|message-entities|middlewares|low-level-api)\.md/,
       Observability: ~r/guides\/(telemetry|opentelemetry)\.md/,
       Advanced: ~r/guides\/(multiple-bots|flyio|bot-init-hooks)\.md/,
       Testing: "guides/testing.md",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for ExGram Router (declarative update routing) and ExGram FSM (multi-step finite-state flows), plus a "Beyond handle/2" section linking them.
  * Reorganized docs with a new "Intermediate" section, updated navigation/next-steps, and an "Ecosystem" section highlighting companion libraries.
* **Chores**
  * Added a .gitignore rule to ignore files matching *.dexter*.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->